### PR TITLE
Fix for celery error

### DIFF
--- a/DataQualityTester/tasks.py
+++ b/DataQualityTester/tasks.py
@@ -115,7 +115,7 @@ def test_file_task(self, path_to_file, component_path, component_id,
                     for el in elements:
                         out = test(el,
                                    codelists=codelists,
-                                   verbose=True)
+                                   bdd_verbose=True)
                         result[lookup.get(out[0])] += 1
                         if out[0] is False:
                             csv_file.writerow(out[1].split(': ', 1))

--- a/DataQualityTester/tasks.py
+++ b/DataQualityTester/tasks.py
@@ -118,7 +118,7 @@ def test_file_task(self, path_to_file, component_path, component_id,
                                    bdd_verbose=True)
                         result[lookup.get(out[0])] += 1
                         if out[0] is False:
-                            csv_file.writerow(out[1].split(': ', 1))
+                            csv_file.writerow([None, out[1]])
                     results[str(test)] = result
                     score = _compute_score(results)
                     if score is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 lxml==4.2.5
 requests==2.20.1
 
-celery==4.0.2
-redis==3.0.1
+celery==4.3.0
+redis==3.2.1
 uWSGI==2.0.17.1
 psycopg2==2.7.6.1
 


### PR DESCRIPTION
Refs #37. This isn’t quite right (the IATI identifier is missing from the output) but it ought to help a bit.