### PR TITLE
UI: add link to the activity merge tool in the navigation bar

### DIFF
--- a/DataQualityTester/templates/partials/_navigation.html
+++ b/DataQualityTester/templates/partials/_navigation.html
@@ -14,6 +14,7 @@
         <li
 {%- if request.url_rule.endpoint == 'home' %} class="active"{% endif -%}
         ><a href="{{ url_for('home') }}">Home</a></li>
+        <li class="inactive"><a href="https://activitymergetool.publishwhatyoufund.org">Activity Merge Tool</a></li>
       </ul>
       <ul class="nav navbar-nav navbar-right">
         <li class="pwyf-logo">


### PR DESCRIPTION
https://trello.com/c/SqZyqNl2/80-move-merge-tool-onto-the-dqt-server

This adds a link to the navigation bar to provide bi-directional travel between the data quality tester and the merge tool. 